### PR TITLE
Replace "fugly" with "fraudulent"

### DIFF
--- a/words/f.js
+++ b/words/f.js
@@ -96,7 +96,7 @@ words.f = [
 "fattening",
 "favorable",
 "flirtatious",
-"fugly",
+"fraudulent",
 "flashy",
 "flattering",
 "fizzy",


### PR DESCRIPTION
Be nicer to people who have felt fugly at any point in their lives.

For context, "fugly" can mean "fucking ugly" or "fat and ugly".